### PR TITLE
Update process.js -> Negative marks calculation.

### DIFF
--- a/process.js
+++ b/process.js
@@ -221,7 +221,13 @@ function process(){
 				else attempted_2 += 1;
 
 				var is_neg = q.is_neg;
-				var neg_marks = (marks * is_neg)/3.0;
+				//var neg_marks = (marks * is_neg)/3.0;  // because it was taking -0.67 for 2 makrs questoin
+				var neg_marks = 0;
+				if(marks===1.0){
+					neg_marks = 0.33 * is_neg;
+				}else{
+					neg_marks = 0.66 * is_neg;      // here is the correction.
+				}
 
 				if(!kq){
 					// alert(gsid);


### PR DESCRIPTION
For 2 marks questions, it was taking -0.67 as deduction marks. According to rule, it should be -0.66.
I have tried to correct that part.